### PR TITLE
Endret tekst i Vedlegg kap 2.7.2 om synbarhetskoding av veglenker

### DIFF
--- a/registreringsinstrukser/vedlegg/Vedlegg_Fotogrammetrisk_FKB_2026.adoc
+++ b/registreringsinstrukser/vedlegg/Vedlegg_Fotogrammetrisk_FKB_2026.adoc
@@ -11,7 +11,7 @@
 :lang: nb
 :URLrot: https://sosi.geonorge.no/registreringsinstrukser
 :fkb: https://sosi.geonorge.no/Standarder/FKB_generell_del
-:publisert: Oppdatert 2026-05-01
+:publisert: Oppdatert 2026-05-20
 
 CAUTION: {publisert} 
 
@@ -55,6 +55,10 @@ Tabellen under viser en oversikt over når vedlegget har blitt endret.
 
 | 2026-05-01
 | Første versjon av vedlegg 2026
+
+
+| 2026-05-20
+| Endring i kapittel 2.7.2 om synbarhetskoding for NVDB Vegnett Pluss
 
 |===
 
@@ -180,8 +184,8 @@ I kapittel 3. Objekttyper og egenskaper, Konnekteringslenke erstattes avsnittet 
 Ny tekst er "Eksisterende konnekteringslenker skal som hovedregel ikke endres. Avvik fra dette må ev. avtales spesielt. Eksisterende konnekteringslenker skal slettes dersom veglenka den skaper forbindelse til slettes. Eksisterende konnekteringslenker skal geometriforbedres dersom tilstøtende veglenker geometriforbedres. Ved geometriforbedring skal egenskapen _konnekteringslenke Ja_ overføres til ny geometri."
  
 ====  Presisering om synbarhetskoding
-I kapittel 5.1 Registrering av nye veglenker er det i avsnittet om oppsplitting av veglenker i forbindelse med synbarhetskoding lagt til en presisering av hvordan veglenker med vekslende synbarhet skal registreres. 
+I kapittel 5.1 Registrering av nye veglenker er det i avsnittet om oppsplitting av veglenker i forbindelse med synbarhetskoding lagt til en presisering av hvordan veglenker med vekslende synbarhet skal registreres.
 
-Avsnittet er nå som følger: "Så langt det er mulig bør det unngås å ha altfor mange korte og oppstykkede veglenker i forbindelse med synbarhetskoding. Ved vekslende synbarhet, der enkeltstykkene med lik synbarhet er under 20 meter, skal veglenka ikke splittes opp, og synbarheten settes til den dominerende synbarheten til veglenka. Les mer om Synbarhet i kap.4.2." 
+Avsnittet er nå som følger: "Så langt det er mulig bør det unngås å ha altfor mange korte og oppstykkede veglenker i forbindelse med synbarhetskoding. Hvis en lenke som konstrueres inneholder punkter med ulik synbarhet, skal lenken gis synbarhetskode tilsvarende majoriteten av punktene sin synbarhet. Les mer om Synbarhet i kap.4.3." 
 
  

--- a/registreringsinstrukser/vedlegg/Vedlegg_Fotogrammetrisk_FKB_2026.html
+++ b/registreringsinstrukser/vedlegg/Vedlegg_Fotogrammetrisk_FKB_2026.html
@@ -510,7 +510,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="title">Caution</div>
 </td>
 <td class="content">
-Oppdatert 2026-05-01
+Oppdatert 2026-05-20
 </td>
 </tr>
 </table>
@@ -583,6 +583,10 @@ For fotogrammetriske registreringsinstrukser som ikke ble revidert 2025-01-01 er
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">2026-05-01</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Første versjon av vedlegg 2026</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2026-05-20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Endring i kapittel 2.7.2 om synbarhetskoding for NVDB Vegnett Pluss</p></td>
 </tr>
 </tbody>
 </table>
@@ -765,7 +769,7 @@ For fotogrammetriske registreringsinstrukser som ikke ble revidert 2025-01-01 er
 <p>I kapittel 5.1 Registrering av nye veglenker er det i avsnittet om oppsplitting av veglenker i forbindelse med synbarhetskoding lagt til en presisering av hvordan veglenker med vekslende synbarhet skal registreres.</p>
 </div>
 <div class="paragraph">
-<p>Avsnittet er nå som følger: "Så langt det er mulig bør det unngås å ha altfor mange korte og oppstykkede veglenker i forbindelse med synbarhetskoding. Ved vekslende synbarhet, der enkeltstykkene med lik synbarhet er under 20 meter, skal veglenka ikke splittes opp, og synbarheten settes til den dominerende synbarheten til veglenka. Les mer om Synbarhet i kap.4.2."</p>
+<p>Avsnittet er nå som følger: "Så langt det er mulig bør det unngås å ha altfor mange korte og oppstykkede veglenker i forbindelse med synbarhetskoding. Hvis en lenke som konstrueres inneholder punkter med ulik synbarhet, skal lenken gis synbarhetskode tilsvarende majoriteten av punktene sin synbarhet. Les mer om Synbarhet i kap.4.3."</p>
 </div>
 </div>
 </div>
@@ -774,7 +778,7 @@ For fotogrammetriske registreringsinstrukser som ikke ble revidert 2025-01-01 er
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-04-28 10:36:43 +0200
+Last updated 2026-05-20 12:37:27 +0200
 </div>
 </div>
 </body>


### PR DESCRIPTION
Teksten er endret til at hvis en lenke som konstrueres inneholder punkter med ulik synbarhet, skal lenken gis synbarhetskode tilsvarende majoriteten av punktene sin synbarhet. Også oppdatert endringslogg og utgivelsesdato.